### PR TITLE
Add dedicated `Compressor` and `Decompressor` classes, deprecate `ZlibFilterStream`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ each individual file chunk:
 $loop = React\EventLoop\Factory::create();
 $stream = new React\Stream\ReadableResourceStream(fopen('access.log.gz', 'r'), $loop);
 
-$decompressor = ZlibFilterStream::createGzipDecompressor();
+$decompressor = ZlibFilterStream::createDecompressor(ZLIB_ENCODING_GZIP);
 
 $decompressor->on('data', function ($data) {
     echo $data;
@@ -58,6 +58,7 @@ The zlib library offers a number of different formats (sometimes referred to as 
 This library supports the GZIP compression format as defined in [RFC 1952](https://tools.ietf.org/html/rfc1952).
 This is one of the more common compression formats and is used in several places:
 
+* PHP: `ZLIB_ENCODING_GZIP` (PHP 5.4+ only)
 * PHP: `gzdecode()` (PHP 5.4+ only) and `gzencode()`
 * Files with `.gz` file extension, e.g. `.tar.gz` or `.tgz` archives (also known as "tarballs")
 * `gzip` and `gunzip` (and family) command line tools
@@ -76,11 +77,12 @@ This library supports the raw DEFLATE compression format as defined in [RFC 1951
 The DEFLATE compression algorithm returns what we refer to as "raw DEFLATE format".
 This raw DEFLATE format is commonly wrapped in container formats instead of being used directly:
 
+* PHP: `ZLIB_ENCODING_RAW` (PHP 5.4+ only)
 * PHP: `gzdeflate()` and `gzinflate()`
 * Wrapped in [GZIP format](#gzip-format)
 * Wrapped in [ZLIB format](#zlib-format)
 
-> Note: This format is not the confused with what some people call "deflate format" or "deflate encoding".
+> Note: This format is not to be confused with what some people call "deflate format" or "deflate encoding".
 These names are commonly used to refer to what we call [ZLIB format](#zlib-format).
 
 ### ZLIB format
@@ -88,6 +90,7 @@ These names are commonly used to refer to what we call [ZLIB format](#zlib-forma
 This library supports the ZLIB compression format as defined in [RFC 1950](https://tools.ietf.org/html/rfc1950).
 This format is commonly used in a streaming context:
 
+* PHP: `ZLIB_ENCODING_DEFLATE` (PHP 5.4+ only)
 * PHP: `gzcompress()` and `gzuncompress()`
 * [HTTP compression](https://en.wikipedia.org/wiki/HTTP_compression) with `Content-Encoding: deflate` header
 * Java: `DeflaterOutputStream`
@@ -115,9 +118,17 @@ stream compression filters offered via `ext-zlib`.
 
 #### createCompressor()
 
-The following methods can be used to create a compressor instance:
+The following method can be used to create a compressor instance:
 
 ```php
+$encoding = ZLIB_ENCODING_GZIP; // or ZLIB_ENCODING_RAW or ZLIB_ENCODING_DEFLATE
+$compressor = ZlibFilterStream::createCompressor($encoding);
+```
+
+The following deprecated methods automatically pass in the respective encoding parameter:
+
+```php
+// deprecated
 $compressor = ZlibFilterStream::createGzipCompressor();
 $compressor = ZlibFilterStream::createDeflateCompressor();
 $compressor = ZlibFilterStream::createZlibCompressor();
@@ -125,9 +136,17 @@ $compressor = ZlibFilterStream::createZlibCompressor();
 
 #### createDecompressor()
 
-The following methods can be used to create a decompressor instance:
+The following method can be used to create a decompressor instance:
 
 ```php
+$encoding = ZLIB_ENCODING_GZIP; // or ZLIB_ENCODING_RAW or ZLIB_ENCODING_DEFLATE
+$compressor = ZlibFilterStream::createDecompressor($encoding);
+```
+
+The following deprecated methods automatically pass in the respective encoding parameter:
+
+```php
+// deprecated
 $decompressor = ZlibFilterStream::createGzipDecompressor();
 $decompressor = ZlibFilterStream::createDeflateDecompressor();
 $decompressor = ZlibFilterStream::createZlibDecompressor();

--- a/examples/gunzip.php
+++ b/examples/gunzip.php
@@ -12,7 +12,7 @@ $loop = React\EventLoop\Factory::create();
 $in = new React\Stream\ReadableResourceStream(STDIN, $loop);
 $out = new React\Stream\WritableResourceStream(STDOUT, $loop);
 
-$decompressor = Clue\React\Zlib\ZlibFilterStream::createDecompressor(ZLIB_ENCODING_GZIP);
+$decompressor = new Clue\React\Zlib\Decompressor(ZLIB_ENCODING_GZIP);
 $in->pipe($decompressor)->pipe($out);
 
 $decompressor->on('error', function ($e) {

--- a/examples/gunzip.php
+++ b/examples/gunzip.php
@@ -2,12 +2,17 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 
+if (!defined('ZLIB_ENCODING_GZIP')) {
+    fwrite(STDERR, 'Requires PHP 5.4+ with ext-zlib enabled' . PHP_EOL);
+    exit(1);
+}
+
 $loop = React\EventLoop\Factory::create();
 
 $in = new React\Stream\ReadableResourceStream(STDIN, $loop);
 $out = new React\Stream\WritableResourceStream(STDOUT, $loop);
 
-$decompressor = Clue\React\Zlib\ZlibFilterStream::createGzipDecompressor();
+$decompressor = Clue\React\Zlib\ZlibFilterStream::createDecompressor(ZLIB_ENCODING_GZIP);
 $in->pipe($decompressor)->pipe($out);
 
 $decompressor->on('error', function ($e) {

--- a/examples/gzip.php
+++ b/examples/gzip.php
@@ -2,12 +2,17 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 
+if (!defined('ZLIB_ENCODING_GZIP')) {
+    fwrite(STDERR, 'Requires PHP 5.4+ with ext-zlib enabled' . PHP_EOL);
+    exit(1);
+}
+
 $loop = React\EventLoop\Factory::create();
 
 $in = new React\Stream\ReadableResourceStream(STDIN, $loop);
 $out = new React\Stream\WritableResourceStream(STDOUT, $loop);
 
-$compressor = Clue\React\Zlib\ZlibFilterStream::createGzipCompressor(1);
+$compressor = Clue\React\Zlib\ZlibFilterStream::createCompressor(ZLIB_ENCODING_GZIP);
 $in->pipe($compressor)->pipe($out);
 
 $loop->run();

--- a/examples/gzip.php
+++ b/examples/gzip.php
@@ -12,7 +12,7 @@ $loop = React\EventLoop\Factory::create();
 $in = new React\Stream\ReadableResourceStream(STDIN, $loop);
 $out = new React\Stream\WritableResourceStream(STDOUT, $loop);
 
-$compressor = Clue\React\Zlib\ZlibFilterStream::createCompressor(ZLIB_ENCODING_GZIP);
+$compressor = new Clue\React\Zlib\Compressor(ZLIB_ENCODING_GZIP);
 $in->pipe($compressor)->pipe($out);
 
 $loop->run();

--- a/src/Compressor.php
+++ b/src/Compressor.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Clue\React\Zlib;
+
+use Clue\StreamFilter as Filter;
+
+/**
+ * The `Compressor` class can be used to compress a stream of data.
+ *
+ * It implements the [`DuplexStreamInterface`](https://github.com/reactphp/stream#duplexstreaminterface)
+ * and accepts uncompressed data on its writable side and emits compressed data
+ * on its readable side.
+ *
+ * ```php
+ * $encoding = ZLIB_ENCODING_GZIP; // or ZLIB_ENCODING_RAW or ZLIB_ENCODING_DEFLATE
+ * $compressor = new Clue\React\Zlib\Compressor($encoding);
+ *
+ * $compressor->on('data', function ($data) {
+ *     echo $data; // compressed binary data chunk
+ * });
+ *
+ * $compressor->write($uncompressed); // write uncompressed data chunk
+ * ```
+ *
+ * This is particularly useful in a piping context:
+ *
+ * ```php
+ * $input->pipe($filterBadWords)->pipe($compressor)->pipe($output);
+ * ```
+ *
+ * For more details, see ReactPHP's
+ * [`DuplexStreamInterface`](https://github.com/reactphp/stream#duplexstreaminterface).
+ *
+ * >   Internally, it implements the deprecated `ZlibFilterStream` class only for
+ *     BC reasons. For best forwards compatibility, you should only rely on it
+ *     implementing the `DuplexStreamInterface`.
+ */
+final class Compressor extends ZlibFilterStream
+{
+    /**
+     * @param int $encoding ZLIB_ENCODING_GZIP, ZLIB_ENCODING_RAW or ZLIB_ENCODING_DEFLATE
+     * @param int $level    optional compression level
+     */
+    public function __construct($encoding, $level = -1)
+    {
+        parent::__construct(
+            Filter\fun('zlib.deflate', array('window' => $encoding, 'level' => $level))
+        );
+    }
+}

--- a/src/Decompressor.php
+++ b/src/Decompressor.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Clue\React\Zlib;
+
+use Clue\StreamFilter as Filter;
+
+/**
+ * The `Decompressor` class can be used to decompress a stream of data.
+ *
+ * It implements the [`DuplexStreamInterface`](https://github.com/reactphp/stream#duplexstreaminterface)
+ * and accepts compressed data on its writable side and emits decompressed data
+ * on its readable side.
+ *
+ * ```php
+ * $encoding = ZLIB_ENCODING_GZIP; // or ZLIB_ENCODING_RAW or ZLIB_ENCODING_DEFLATE
+ * $decompressor = new Clue\React\Zlib\Decompressor($encoding);
+ *
+ * $decompressor->on('data', function ($data) {
+ *     echo $data; // decompressed data chunk
+ * });
+ *
+ * $decompressor->write($compressed); // write compressed binary data chunk
+ * ```
+ *
+ * This is particularly useful in a piping context:
+ *
+ * ```php
+ * $input->pipe($decompressor)->pipe($filterBadWords)->pipe($output);
+ * ```
+ *
+ * For more details, see ReactPHP's
+ * [`DuplexStreamInterface`](https://github.com/reactphp/stream#duplexstreaminterface).
+ *
+ * >   Internally, it implements the deprecated `ZlibFilterStream` class only for
+ *     BC reasons. For best forwards compatibility, you should only rely on it
+ *     implementing the `DuplexStreamInterface`.
+ */
+final class Decompressor extends ZlibFilterStream
+{
+    /**
+     * @param int $encoding ZLIB_ENCODING_GZIP, ZLIB_ENCODING_RAW or ZLIB_ENCODING_DEFLATE
+     */
+    public function __construct($encoding)
+    {
+        parent::__construct(
+            Filter\fun('zlib.inflate', array('window' => $encoding))
+        );
+    }
+}

--- a/src/TransformStream.php
+++ b/src/TransformStream.php
@@ -9,7 +9,7 @@ use React\Stream\Util;
 use Exception;
 
 /**
- * @internal Should not be relied upon outside of this package. Should eventually be moved to react/stream?
+ * @internal Should not be relied upon outside of this package.
  */
 class TransformStream extends EventEmitter implements DuplexStreamInterface
 {

--- a/src/ZlibFilterStream.php
+++ b/src/ZlibFilterStream.php
@@ -2,8 +2,6 @@
 
 namespace Clue\React\Zlib;
 
-use Clue\StreamFilter as Filter;
-
 /**
  * Compressor and decompressor using PHP's zlib compression filters.
  *
@@ -14,39 +12,19 @@ use Clue\StreamFilter as Filter;
  * RFC 1950 (ZLIB compressed format)
  *
  * @link http://php.net/manual/en/filters.compression.php
+ * @deprecated 0.2.2 External usage of `ZlibFilterStream` is deprecated, use `Compressor` or `Decompressor` instead.
+ * @see Compressor
+ * @see Decompressor
  */
 class ZlibFilterStream extends TransformStream
 {
-    /**
-     * @param int $encoding ZLIB_ENCODING_GZIP, ZLIB_ENCODING_RAW or ZLIB_ENCODING_DEFLATE
-     * @param int $level    optional compression level
-     * @return self
-     */
-    public static function createCompressor($encoding, $level = -1)
-    {
-        return new self(
-            Filter\fun('zlib.deflate', array('window' => $encoding, 'level' => $level))
-        );
-    }
-
-    /**
-     * @param int $encoding ZLIB_ENCODING_GZIP, ZLIB_ENCODING_RAW or ZLIB_ENCODING_DEFLATE
-     * @return self
-     */
-    public static function createDecompressor($encoding)
-    {
-        return new self(
-            Filter\fun('zlib.inflate', array('window' => $encoding))
-        );
-    }
-
     /**
      * @deprecated
      * @return self
      */
     public static function createGzipCompressor($level = -1)
     {
-        return self::createCompressor(15 | 16 /* ZLIB_ENCODING_GZIP */, $level);
+        return new Compressor(15 | 16 /* ZLIB_ENCODING_GZIP */, $level);
     }
 
     /**
@@ -55,7 +33,7 @@ class ZlibFilterStream extends TransformStream
      */
     public static function createGzipDecompressor()
     {
-        return self::createDecompressor(15 | 16 /* ZLIB_ENCODING_GZIP */);
+        return new Decompressor(15 | 16 /* ZLIB_ENCODING_GZIP */);
     }
 
     /**
@@ -64,7 +42,7 @@ class ZlibFilterStream extends TransformStream
      */
     public static function createDeflateCompressor($level = -1)
     {
-        return self::createCompressor(-15 /* ZLIB_ENCODING_RAW */, $level);
+        return new Compressor(-15 /* ZLIB_ENCODING_RAW */, $level);
     }
 
     /**
@@ -73,7 +51,7 @@ class ZlibFilterStream extends TransformStream
      */
     public static function createDeflateDecompressor()
     {
-        return self::createDecompressor(-15 /* ZLIB_ENCODING_RAW */);
+        return new Decompressor(-15 /* ZLIB_ENCODING_RAW */);
     }
 
     /**
@@ -82,7 +60,7 @@ class ZlibFilterStream extends TransformStream
      */
     public static function createZlibCompressor($level = -1)
     {
-        return self::createCompressor(15 /* ZLIB_ENCODING_DEFLATE */, $level);
+        return new Compressor(15 /* ZLIB_ENCODING_DEFLATE */, $level);
     }
 
     /**
@@ -91,7 +69,7 @@ class ZlibFilterStream extends TransformStream
      */
     public static function createZlibDecompressor()
     {
-        return self::createDecompressor(15 /* ZLIB_ENCODING_DEFLATE */);
+        return new Decompressor(15 /* ZLIB_ENCODING_DEFLATE */);
     }
 
     private $filter;

--- a/src/ZlibFilterStream.php
+++ b/src/ZlibFilterStream.php
@@ -17,46 +17,81 @@ use Clue\StreamFilter as Filter;
  */
 class ZlibFilterStream extends TransformStream
 {
+    /**
+     * @param int $encoding ZLIB_ENCODING_GZIP, ZLIB_ENCODING_RAW or ZLIB_ENCODING_DEFLATE
+     * @param int $level    optional compression level
+     * @return self
+     */
+    public static function createCompressor($encoding, $level = -1)
+    {
+        return new self(
+            Filter\fun('zlib.deflate', array('window' => $encoding, 'level' => $level))
+        );
+    }
+
+    /**
+     * @param int $encoding ZLIB_ENCODING_GZIP, ZLIB_ENCODING_RAW or ZLIB_ENCODING_DEFLATE
+     * @return self
+     */
+    public static function createDecompressor($encoding)
+    {
+        return new self(
+            Filter\fun('zlib.inflate', array('window' => $encoding))
+        );
+    }
+
+    /**
+     * @deprecated
+     * @return self
+     */
     public static function createGzipCompressor($level = -1)
     {
-        return new self(
-            Filter\fun('zlib.deflate', array('window' => 15|16, 'level' => $level))
-        );
+        return self::createCompressor(15 | 16 /* ZLIB_ENCODING_GZIP */, $level);
     }
 
+    /**
+     * @deprecated
+     * @return self
+     */
     public static function createGzipDecompressor()
     {
-        return new self(
-            Filter\fun('zlib.inflate', array('window' => 15|16))
-        );
+        return self::createDecompressor(15 | 16 /* ZLIB_ENCODING_GZIP */);
     }
 
+    /**
+     * @deprecated
+     * @return self
+     */
     public static function createDeflateCompressor($level = -1)
     {
-        return new self(
-            Filter\fun('zlib.deflate', array('window' => -15, 'level' => $level))
-        );
+        return self::createCompressor(-15 /* ZLIB_ENCODING_RAW */, $level);
     }
 
+    /**
+     * @deprecated
+     * @return self
+     */
     public static function createDeflateDecompressor()
     {
-        return new self(
-            Filter\fun('zlib.inflate', array('window' => -15))
-        );
+        return self::createDecompressor(-15 /* ZLIB_ENCODING_RAW */);
     }
 
+    /**
+     * @deprecated
+     * @return self
+     */
     public static function createZlibCompressor($level = -1)
     {
-        return new self(
-            Filter\fun('zlib.deflate', array('window' => 15, 'level' => $level))
-        );
+        return self::createCompressor(15 /* ZLIB_ENCODING_DEFLATE */, $level);
     }
 
+    /**
+     * @deprecated
+     * @return self
+     */
     public static function createZlibDecompressor()
     {
-        return new self(
-            Filter\fun('zlib.inflate', array('window' => 15))
-        );
+        return self::createDecompressor(15 /* ZLIB_ENCODING_DEFLATE */);
     }
 
     private $filter;


### PR DESCRIPTION
```php
// old
$compressor = Clue\React\Zlib\ZlibFilterStream::createGzipCompressor();

// new
$compressor = new Clue\React\Zlib\Compressor(ZLIB_ENCODING_GZIP);
```

Among others, this is done in preparation for #4.