### PR TITLE
Require ext-zlib during installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,17 +248,22 @@ $ composer require clue/zlib-react:^0.2.2
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 
 This project aims to run on any platform and thus does not require any PHP
-extensions and supports running on legacy PHP 5.4 through current PHP 7+.
+extensions besides `ext-zlib` and supports running on legacy PHP 5.4 through current
+PHP 7+.
 It's *highly recommended to use PHP 7+* for this project.
 
-The `ext-zlib` extension is not required to install this library, however it
-is required to actually do anything meaningful with this library.
-Each of the above methods will throw an `Exception` if this extension is
-missing.
+The `ext-zlib` extension is required for handling the underlying data compression
+and decompression.
+This extension is already installed as part of many PHP distributions out-of-the-box,
+e.g. it ships with Debian/Ubuntu-based PHP installations and Windows-based
+builds by default. If you're building PHP from source, you may have to
+[manually enable](https://www.php.net/manual/en/zlib.installation.php) it.
 
 We're committed to providing a smooth upgrade path for legacy setups.
 If you need to support legacy PHP 5.3 and legacy HHVM, you may want to check out
 the legacy `v0.2.x` release branch.
+This legacy release branch also provides an installation candidate that does not
+require `ext-zlib` during installation but uses runtime checks instead.
 
 ## Tests
 

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     ],
     "require": {
         "php": ">=5.4",
+        "ext-zlib": "*",
         "clue/stream-filter": "~1.3",
         "react/stream": "^1.0 || ^0.7 || ^0.6"
     },

--- a/examples/91-benchmark-compress.php
+++ b/examples/91-benchmark-compress.php
@@ -22,12 +22,6 @@ if (DIRECTORY_SEPARATOR === '\\') {
     exit(1);
 }
 
-if (!defined('ZLIB_ENCODING_GZIP')) {
-    fwrite(STDERR, 'Requires PHP with ext-zlib enabled' . PHP_EOL);
-    exit(1);
-}
-
-
 if (extension_loaded('xdebug')) {
     echo 'NOTICE: The "xdebug" extension is loaded, this has a major impact on performance.' . PHP_EOL;
 }

--- a/examples/92-benchmark-decompress.php
+++ b/examples/92-benchmark-decompress.php
@@ -26,11 +26,6 @@ if (DIRECTORY_SEPARATOR === '\\') {
     exit(1);
 }
 
-if (!defined('ZLIB_ENCODING_GZIP')) {
-    fwrite(STDERR, 'Requires PHP with ext-zlib enabled' . PHP_EOL);
-    exit(1);
-}
-
 if ($argc !== 2) {
     fwrite(STDERR, 'No archive given, requires single argument' . PHP_EOL);
     exit(1);

--- a/examples/gunzip.php
+++ b/examples/gunzip.php
@@ -7,11 +7,6 @@ if (DIRECTORY_SEPARATOR === '\\') {
     exit(1);
 }
 
-if (!defined('ZLIB_ENCODING_GZIP')) {
-    fwrite(STDERR, 'Requires PHP with ext-zlib enabled' . PHP_EOL);
-    exit(1);
-}
-
 $loop = React\EventLoop\Factory::create();
 
 $in = new React\Stream\ReadableResourceStream(STDIN, $loop);

--- a/examples/gzip.php
+++ b/examples/gzip.php
@@ -7,11 +7,6 @@ if (DIRECTORY_SEPARATOR === '\\') {
     exit(1);
 }
 
-if (!defined('ZLIB_ENCODING_GZIP')) {
-    fwrite(STDERR, 'Requires PHP with ext-zlib enabled' . PHP_EOL);
-    exit(1);
-}
-
 $loop = React\EventLoop\Factory::create();
 
 $in = new React\Stream\ReadableResourceStream(STDIN, $loop);

--- a/src/ZlibFilterStream.php
+++ b/src/ZlibFilterStream.php
@@ -24,7 +24,7 @@ class ZlibFilterStream extends TransformStream
      */
     public static function createGzipCompressor($level = -1)
     {
-        return new Compressor(15 | 16 /* ZLIB_ENCODING_GZIP */, $level);
+        return new Compressor(ZLIB_ENCODING_GZIP, $level);
     }
 
     /**
@@ -33,7 +33,7 @@ class ZlibFilterStream extends TransformStream
      */
     public static function createGzipDecompressor()
     {
-        return new Decompressor(15 | 16 /* ZLIB_ENCODING_GZIP */);
+        return new Decompressor(ZLIB_ENCODING_GZIP);
     }
 
     /**
@@ -42,7 +42,7 @@ class ZlibFilterStream extends TransformStream
      */
     public static function createDeflateCompressor($level = -1)
     {
-        return new Compressor(-15 /* ZLIB_ENCODING_RAW */, $level);
+        return new Compressor(ZLIB_ENCODING_RAW, $level);
     }
 
     /**
@@ -51,7 +51,7 @@ class ZlibFilterStream extends TransformStream
      */
     public static function createDeflateDecompressor()
     {
-        return new Decompressor(-15 /* ZLIB_ENCODING_RAW */);
+        return new Decompressor(ZLIB_ENCODING_RAW);
     }
 
     /**
@@ -60,7 +60,7 @@ class ZlibFilterStream extends TransformStream
      */
     public static function createZlibCompressor($level = -1)
     {
-        return new Compressor(15 /* ZLIB_ENCODING_DEFLATE */, $level);
+        return new Compressor(ZLIB_ENCODING_DEFLATE, $level);
     }
 
     /**
@@ -69,7 +69,7 @@ class ZlibFilterStream extends TransformStream
      */
     public static function createZlibDecompressor()
     {
-        return new Decompressor(15 /* ZLIB_ENCODING_DEFLATE */);
+        return new Decompressor(ZLIB_ENCODING_DEFLATE);
     }
 
     private $filter;


### PR DESCRIPTION
Builds on top of #25, so we can now rely on required constants to be present (as of PHP 5.4+).