### PR TITLE
Run tests on PHPUnit 9 and update PHPUnit configuration schema for PHPUnit 9.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,5 @@
 /.gitignore export-ignore
 /examples/ export-ignore
 /phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
 /tests/ export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,6 @@ jobs:
           coverage: xdebug
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text
+        if: ${{ matrix.php >= 7.3 }}
+      - run: vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy
+        if: ${{ matrix.php < 7.3 }}

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "react/stream": "^1.0 || ^0.7 || ^0.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0 || ^6.0",
+        "phpunit/phpunit": "^9.3 || ^6.5",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3"
     },
     "suggest": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php" colors="true">
+<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheResult="false">
     <testsuites>
         <testsuite name="zlib React Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="zlib React Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/CompressorTest.php
+++ b/tests/CompressorTest.php
@@ -6,11 +6,9 @@ use Clue\React\Zlib\Compressor;
 
 class CompressorTest extends TestCase
 {
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testCtorThrowsForInvalidEncoding()
     {
+        $this->expectException('InvalidArgumentException');
         new Compressor(0);
     }
 }

--- a/tests/DecompressorTest.php
+++ b/tests/DecompressorTest.php
@@ -6,11 +6,9 @@ use Clue\React\Zlib\Decompressor;
 
 class DecompressorTest extends TestCase
 {
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testCtorThrowsForInvalidEncoding()
     {
+        $this->expectException('InvalidArgumentException');
         new Decompressor(0);
     }
 }

--- a/tests/DeflateDecompressorTest.php
+++ b/tests/DeflateDecompressorTest.php
@@ -8,7 +8,10 @@ class DeflateDecompressorTest extends TestCase
 {
     private $decompressor;
 
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpDecompressor()
     {
         $this->decompressor = new Decompressor(ZLIB_ENCODING_RAW);
     }

--- a/tests/DelateCompressorTest.php
+++ b/tests/DelateCompressorTest.php
@@ -8,7 +8,10 @@ class DeflateCompressorTest extends TestCase
 {
     private $compressor;
 
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpCompressor()
     {
         $this->compressor = new Compressor(ZLIB_ENCODING_RAW);
     }

--- a/tests/FunctionalExamplesTest.php
+++ b/tests/FunctionalExamplesTest.php
@@ -4,7 +4,10 @@ namespace Clue\Tests\React\Zlib;
 
 class FunctionalExamplesTest extends TestCase
 {
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpSkipTest()
     {
         if (DIRECTORY_SEPARATOR === '\\') {
             $this->markTestSkipped('Non-blocking console I/O not supported on Windows');

--- a/tests/GzipCompressorTest.php
+++ b/tests/GzipCompressorTest.php
@@ -8,7 +8,10 @@ class GzipCompressorTest extends TestCase
 {
     private $compressor;
 
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpCompressor()
     {
         $this->compressor = new Compressor(ZLIB_ENCODING_GZIP);
     }

--- a/tests/GzipDecompressorTest.php
+++ b/tests/GzipDecompressorTest.php
@@ -8,7 +8,10 @@ class GzipDecompressorTest extends TestCase
 {
     private $decompressor;
 
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpDecompressor()
     {
         $this->decompressor = new Decompressor(ZLIB_ENCODING_GZIP);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -39,6 +39,12 @@ class TestCase extends \PHPUnit\Framework\TestCase
 
     protected function createCallableMock()
     {
-        return $this->getMockBuilder('stdClass')->setMethods(array('__invoke'))->getMock();
+        if (method_exists('PHPUnit\Framework\MockObject\MockBuilder', 'addMethods')) {
+            // PHPUnit 8.5+
+            return $this->getMockBuilder('stdClass')->addMethods(array('__invoke'))->getMock();
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 8.4
+            return $this->getMockBuilder('stdClass')->setMethods(array('__invoke'))->getMock();
+        }
     }
 }

--- a/tests/ZlibCompressorTest.php
+++ b/tests/ZlibCompressorTest.php
@@ -8,7 +8,10 @@ class ZlibCompressorTest extends TestCase
 {
     private $compressor;
 
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpCompressor()
     {
         $this->compressor = new Compressor(ZLIB_ENCODING_DEFLATE);
     }

--- a/tests/ZlibDecompressorTest.php
+++ b/tests/ZlibDecompressorTest.php
@@ -8,7 +8,10 @@ class ZlibDecompressorTest extends TestCase
 {
     private $decompressor;
 
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpDecompressor()
     {
         $this->decompressor = new Decompressor(ZLIB_ENCODING_DEFLATE);
     }


### PR DESCRIPTION
PHPUnit 9.3 released a new schema for the `phpunit.xml` configuration file. I had to migrate the file to the new format in order to avoid the warning. PHPUnit Versions older than 9.3 have to use the `phpunit.xml.legacy` configuration file, because the new format is unknown for them.
For further details concerning this pull request look into https://github.com/graphp/graphviz/pull/46.
This pull request builds on top of #30.