### PR TITLE
Update test environment to fix tests on legacy PHP 7.2 with PHPUnit 8.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,4 @@ jobs:
           extensions: zlib
           coverage: xdebug
       - run: composer install
-      - run: vendor/bin/phpunit --coverage-text
-        if: ${{ matrix.php >= 7.3 }}
-      - run: vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy
-        if: ${{ matrix.php < 7.3 }}
+      - run: vendor/bin/phpunit --coverage-text ${{ matrix.php < 7.3 && '-c phpunit.xml.legacy' || '' }}

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "react/stream": "^1.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.6 || ^6.5",
+        "phpunit/phpunit": "^9.6 || ^8.5 || ^6.5",
         "react/event-loop": "^1.2"
     },
     "autoload": {


### PR DESCRIPTION
This changeset updates the test environment to fix tests on legacy PHP 7.2 with PHPUnit 8.5. This is needed to run the tests on legacy platforms due to recent upstream changes as discussed in https://github.com/clue/reactphp-redis/pull/180.

Builds on top of #40 and https://github.com/clue/reactphp-redis/pull/180