### PR TITLE
Run tests on PHP 8.5 and update test environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
           - ubuntu-24.04
           - windows-2025
         php:
+          - 8.5
           - 8.4
           - 8.3
           - 8.2
@@ -25,7 +26,7 @@ jobs:
           - 7.1
           - 7.0
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
     "require": {
         "php": ">=7.0",
         "ext-zlib": "*",
-        "react/stream": "^1.2"
+        "react/stream": "^1.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6 || ^8.5 || ^6.5",
-        "react/event-loop": "^1.2"
+        "react/event-loop": "^1.6"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This changeset updates the test environment to run the test suite on PHP 8.5.

Builds on top of #42, #40, https://github.com/reactphp/stream/pull/179, https://github.com/reactphp/event-loop/pull/282, and https://github.com/clue/framework-x/pull/297