### PR TITLE
Update test suite to ensure 100% code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,10 @@ jobs:
           extensions: zlib
           coverage: xdebug
       - run: composer install
-      - run: vendor/bin/phpunit --coverage-text ${{ matrix.php < 7.3 && '-c phpunit.xml.legacy' || '' }}
+      - run: vendor/bin/phpunit --coverage-text --coverage-clover clover.xml ${{ matrix.php < 7.3 && '-c phpunit.xml.legacy' || '' }}
+      - name: Check 100% code coverage
+        shell: php {0}
+        run: |
+          <?php
+          $metrics = simplexml_load_file('clover.xml')->project->metrics;
+          exit((int) $metrics['statements'] === (int) $metrics['coveredstatements'] ? 0 : 1);

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # clue/reactphp-zlib
 
 [![CI status](https://github.com/clue/reactphp-zlib/actions/workflows/ci.yml/badge.svg)](https://github.com/clue/reactphp-zlib/actions)
+[![code coverage](https://img.shields.io/badge/code%20coverage-100%25-success)](#tests)
 [![installs on Packagist](https://img.shields.io/packagist/dt/clue/zlib-react?color=blue&label=installs%20on%20Packagist)](https://packagist.org/packages/clue/zlib-react)
 
 Streaming zlib compressor and decompressor for [ReactPHP](https://reactphp.org/),
@@ -219,6 +220,14 @@ To run the test suite, go to the project root and run:
 
 ```bash
 vendor/bin/phpunit
+```
+
+The test suite is set up to always ensure 100% code coverage across all
+supported environments. If you have the Xdebug extension installed, you can also
+generate a code coverage report locally like this:
+
+```bash
+XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-text
 ```
 
 ## License


### PR DESCRIPTION
This changeset updates the CI setup to ensure 100% code coverage.

Builds on top of #43 and https://github.com/clue/reactphp-eventsource/pull/35